### PR TITLE
Fix macOS release and cross compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,14 @@ stages:
   - name: release
     if: tag IS present
 
+env:
+  global:
+   - OSXCROSS_REV=3034f7149716d815bc473d0a7b35d17e4cf175aa
+   - SDK_VERSION=10.11
+   - DARWIN_VERSION=15
+   - OSX_VERSION_MIN=10.6
+   - OSXCROSS_SDK_URL="https://s3.dockerproject.org/darwin/v2/MacOSX10.11.sdk.tar.xz"
+
 jobs:
   include:
     - name: 'All tests'
@@ -34,6 +42,8 @@ jobs:
 
     - name: 'Cross-compile, release & publish to Sonatype'
       stage: release
+      env:
+         - OSXCROSS_PATH="$HOME/osxcross"
       before_install:
         - mkdir -p /tmp/osxcross
         - cd /tmp/osxcross


### PR DESCRIPTION
Important changes were lost in 5761a114d0793f3490511f761c2115a8a61872df - this recovers them.
It fails the [CI release built](https://travis-ci.org/bblfsh/scala-client/builds/556384306) otherwise.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/scala-client/98)
<!-- Reviewable:end -->
