### PR TITLE
High-level helpers around UAST decode/load

### DIFF
--- a/src/main/scala/org/bblfsh/client/v2/BblfshClient.scala
+++ b/src/main/scala/org/bblfsh/client/v2/BblfshClient.scala
@@ -130,11 +130,13 @@ object BblfshClient {
     libuast.decode(buf)
   }
 
-  // Enables API: resp.uast.decode()
+  /** Enables API: resp.uast.decode() */
   implicit class UastMethods(val buf: ByteString) {
     /**
-      * Decodes bytes from wired format of bblfsh protocol.v2.
-      * Copies a buffer in Direct mode.
+      * Decodes bytes from wire format of bblfsh protocol.v2.
+      *
+      * Always copies memory to a new buffer in Direct mode,
+      * to be able to pass it to JNI.
       */
     def decode(): ContextExt = {
       val bufDirectCopy = ByteBuffer.allocateDirect(buf.size)
@@ -142,6 +144,17 @@ object BblfshClient {
       BblfshClient.decode(bufDirectCopy)
     }
   }
+
+  /** Enables API: resp.get() */
+  implicit class ResponseMethods(val resp: ParseResponse) {
+    def get(): JNode = {
+      val ctx = resp.uast.decode()
+      val node = ctx.root().load()
+      ctx.dispose()
+      node
+    }
+  }
+
 
   // TODO(bzz): implement iterator
   // def iterator(node: NodeExt, treeOrder: Int): Libuast.NodeIterator = {

--- a/src/test/scala/org/bblfsh/client/v2/BblfshClientLoadTest.scala
+++ b/src/test/scala/org/bblfsh/client/v2/BblfshClientLoadTest.scala
@@ -17,17 +17,17 @@ class BblfshClientLoadTest extends BblfshClientBaseTest {
     val root = rootNode.load()
 
     root should not be Nil
-    root.getClass shouldBe classOf[JObject]
+    root shouldBe a [JObject]
     root.children should not be empty
     root.children.size shouldBe 6
 
     val arr = root.children(1)
     arr should not be (null)
-    arr.getClass shouldBe classOf[JArray]
+    arr shouldBe a [JArray]
     arr.children.size shouldBe 1
 
     val str = arr.children(0)
-    str.getClass shouldBe classOf[JString]
+    str shouldBe a[JString]
 
     val nil = root("imports")
     nil should be (JNull())
@@ -48,6 +48,7 @@ class BblfshClientLoadTest extends BblfshClientBaseTest {
 
     val ctx = Context()
     val bb: ByteBuffer = ctx.encode(rootTree)
+    ctx.dispose()
 
     bb should not be (null)
   }

--- a/src/test/scala/org/bblfsh/client/v2/BblfshClientUastApiTest.scala
+++ b/src/test/scala/org/bblfsh/client/v2/BblfshClientUastApiTest.scala
@@ -1,0 +1,80 @@
+package org.bblfsh.client.v2
+
+import java.nio.ByteBuffer
+
+import com.google.protobuf.ByteString
+
+
+/**
+  * Tests for high-level API wrappers around decode/load,
+  * checking result equivalence to the low-level counterpart.
+  */
+class BblfshClientUastApiTest extends BblfshClientBaseTest {
+
+  import BblfshClient._ // enables uast.* methods
+
+  override val fileName = "src/test/resources/Tiny.java"
+
+  // Depends on having bblfshd JavaScript and Java drivers
+  "SupportedLanguages" should "include aliases" in {
+    val resp = client.supportedLanguages()
+
+    val supportedLangs = resp.languages.flatMap(x => Seq(x.language) ++ x.aliases)
+
+    supportedLangs.length should be > resp.languages.length
+    resp.languages.size should be >= 2
+  }
+
+  "Parse + decode + load UAST" should "result in new JNode"  in {
+    val node1 = resp.uast.decode.root.load()
+
+    val node2 = resp.get()
+
+    node2 should not be (null)
+    node2 shouldBe a [JNode]
+    node1 should equal(node2)
+  }
+
+  "Parse + get binary" should "result in ByteBuffer" in {
+    resp.uast shouldBe a [ByteString]
+  }
+
+  "Decode binary to JVM memory" should "result in new JNode" in {
+    val bytes: Array[Byte] = resp.uast.toByteArray
+    val node1 = resp.uast.decode.root.load()
+
+    val node2 = JNode.parseFrom(bytes)
+    node2 should not be (null)
+    node2 shouldBe a [JNode]
+    node1 should equal(node2)
+
+    val node3 = JNode.parseFrom(resp.uast.asReadOnlyByteBuffer())
+    node3 should not be (null)
+    node3 shouldBe a [JNode]
+    node1 should equal(node3)
+  }
+
+  "Encode JNode to the binary" should "result in bytes" in {
+    val node: JNode = JArray(
+      JObject(
+        "k1" -> JString("v1")
+      ),
+      JString("test")
+    )
+
+    val ctx = Context()
+    val bytes1 = ctx.encode(node)
+    ctx.dispose()
+
+    val bytes2 = node.toByteBuffer
+    bytes2 should not be (null)
+    bytes2 shouldBe a[ByteBuffer]
+    bytes2 should equal(bytes1)
+
+    val bytes3 = node.toByteArray
+    bytes3 should not be (null)
+    bytes3 shouldBe a[Array[Byte]]
+    ByteBuffer.wrap(bytes3) should equal(bytes1)
+  }
+
+}

--- a/src/test/scala/org/bblfsh/client/v2/ContextTest.scala
+++ b/src/test/scala/org/bblfsh/client/v2/ContextTest.scala
@@ -1,0 +1,26 @@
+package org.bblfsh.client.v2
+
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
+
+import scala.io.Source
+
+class ContextTest extends FlatSpec
+  with BeforeAndAfter
+  with Matchers {
+
+
+  "ContextExt" should "be able to .dispose() twice" in {
+    val client = BblfshClient("localhost", 9432)
+    val fileName = "src/test/resources/SampleJavaFile.java"
+    val fileContent = Source.fromFile(fileName).getLines.mkString("\n")
+    val resp = client.parse(fileName, fileContent)
+
+    import BblfshClient._ // enables uast.* methods
+
+    val ctx = resp.uast.decode()
+    ctx.dispose()
+    ctx.dispose()
+  }
+
+
+}


### PR DESCRIPTION
Add new high-level API wrappers around UAST decode/load:

 - `ParseResponse.get()` as a shortcut for both, decoding and loading from gRPC response
 - `JNode.parseFrom()` as a shortcut for decoding and loading rom bytes
 - `JNode` `.toByteBuffer` and `.toByteArray` as a shortcut for encoding

Once merged, I proposed to make an RC2 release with updated API migration guide.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/scala-client/101)
<!-- Reviewable:end -->
