### PR TITLE
Fix encoding for JUint 

### DIFF
--- a/src/main/native/org_bblfsh_client_v2_libuast_Libuast.cc
+++ b/src/main/native/org_bblfsh_client_v2_libuast_Libuast.cc
@@ -164,7 +164,7 @@ class Node : public uast::Node<Node *> {
     } else if (env->IsInstanceOf(obj, env->FindClass(CLS_JBOOL))) {
       return NODE_BOOL;
     } else if (env->IsInstanceOf(obj, env->FindClass(CLS_JUINT))) {
-      return NODE_BOOL;
+      return NODE_UINT;
     } else if (env->IsInstanceOf(obj, env->FindClass(CLS_JARR))) {
       return NODE_ARRAY;
     }
@@ -449,7 +449,7 @@ class Context {
   }
   // toNode returns a node associated with a JVM object.
   // Returns a new reference.
-  Node *toNode(jobject obj) { return iface->lookupOrCreate(obj); }
+  Node *toNode(jobject jnode) { return iface->lookupOrCreate(jnode); }
 
  public:
   Context() {
@@ -475,10 +475,10 @@ class Context {
 
   // Encode serializes UAST.
   // Creates a new reference.
-  jobject Encode(jobject node, UastFormat format) {
-    if (!assertNotContext(node)) return nullptr;
+  jobject Encode(jobject jnode, UastFormat format) {
+    if (!assertNotContext(jnode)) return nullptr;
 
-    Node *n = toNode(node);
+    Node *n = toNode(jnode);
     uast::Buffer data = ctx->Encode(n, format);
     return asJvmBuffer(data);
   }
@@ -547,11 +547,11 @@ JNIEXPORT jobject JNICALL Java_org_bblfsh_client_v2_libuast_Libuast_filter(
 // ==========================================
 
 JNIEXPORT jobject JNICALL Java_org_bblfsh_client_v2_Context_encode(
-    JNIEnv *env, jobject self, jobject node) {
+    JNIEnv *env, jobject self, jobject jnode) {
   UastFormat fmt = UAST_BINARY;  // TODO(bzz): make it argument
 
   Context *p = getHandle<Context>(env, self, nativeContext);
-  return p->Encode(node, fmt);
+  return p->Encode(jnode, fmt);
 }
 
 JNIEXPORT jlong JNICALL

--- a/src/test/resources/python_file.py
+++ b/src/test/resources/python_file.py
@@ -1,25 +1,6 @@
-import os
-import sys
+#!/usr/bin/env python
 
+from __future__ import print_function
 
-class BblfshClient(object):
-    """
-    Babelfish gRPC client. Currently it is only capable of fetching UASTs.
-    """
-
-    def __init__(self, endpoint):
-        """
-        Initializes a new instance of BblfshClient.
-
-        :param endpoint: The address of the Babelfish server, \
-                         for example "0.0.0.0:9432"
-        :type endpoint: str
-        """
-
-    def parse(self, filename, language=None, contents=None, timeout=None,
-                   unicode_errors="ignore"):
-        request = ParseRequest(filename=os.path.basename(filename),
-                                   content=contents,
-                                   language=language)
-        response = self._stub.Parse(request, timeout=timeout)
-        return response
+if __name__ == '__main__':
+  print('hello world')

--- a/src/test/scala/org/bblfsh/client/v2/BblfshClientParseTest.scala
+++ b/src/test/scala/org/bblfsh/client/v2/BblfshClientParseTest.scala
@@ -1,7 +1,7 @@
 package org.bblfsh.client.v2
 
 import java.nio.ByteBuffer
-
+import scala.io.Source
 
 class BblfshClientParseTest extends BblfshClientBaseTest {
 
@@ -34,7 +34,7 @@ class BblfshClientParseTest extends BblfshClientBaseTest {
     uast.dispose()
   }
 
-  "Encoding back the RootNode of decoded UAST" should "produce same bytes" in {
+  "Encoding UAST to the same ContextExt" should "produce the same bytes" in {
     val uastCtx: ContextExt = resp.uast.decode()
     val rootNode: NodeExt = uastCtx.root()
     println(s"Root node: $rootNode")
@@ -47,5 +47,36 @@ class BblfshClientParseTest extends BblfshClientBaseTest {
     println(resp.uast.asReadOnlyByteBuffer)
     println(encodedBytes)
   }
+
+  "Encoding java UAST to a new Context" should "produce the same bytes" in {
+    val node = resp.get
+
+    val encodedBytes = node.toByteBuffer
+
+    val nodeEncodedDecoded = JNode.parseFrom(encodedBytes)
+    nodeEncodedDecoded shouldEqual node
+
+    encodedBytes.capacity should be(resp.uast.asReadOnlyByteBuffer.capacity)
+    encodedBytes shouldEqual resp.uast.asReadOnlyByteBuffer
+  }
+
+
+  "Encoding python UAST to a new Context" should "produce the same bytes" in {
+    val client = BblfshClient("localhost", 9432)
+    val fileName = "src/test/resources/python_file.py"
+    val fileContent = Source.fromFile(fileName).getLines.mkString("\n")
+    val resp = client.parse(fileName, fileContent)
+    val node = resp.get
+
+    // when
+    val encodedBytes = node.toByteBuffer
+
+    val nodeEncodedDecoded = JNode.parseFrom(encodedBytes)
+    nodeEncodedDecoded shouldEqual node
+
+    encodedBytes.capacity should be(resp.uast.asReadOnlyByteBuffer.capacity)
+    encodedBytes shouldEqual resp.uast.asReadOnlyByteBuffer
+  }
+
 
 }


### PR DESCRIPTION
Fixes #104 

 - rename var in native part to avoid type confusion
 - simplify test fixture for python
 - add new tests for decode->new context->encode case

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/scala-client/105)
<!-- Reviewable:end -->
