### PR TITLE
Avoid using JNI refs as map keys

### DIFF
--- a/src/main/native/jni_utils.cc
+++ b/src/main/native/jni_utils.cc
@@ -61,12 +61,12 @@ const char METHOD_RE_INIT_CAUSE[] =
 const char METHOD_ITER_INIT[] = "(Lorg/bblfsh/client/v2/NodeExt;IJLorg/bblfsh/client/v2/ContextExt;)V";
 const char METHOD_JITER_INIT[] = "(Lorg/bblfsh/client/v2/JNode;IJLorg/bblfsh/client/v2/Context;)V";
 
+const char METHOD_NODE_INIT[] = "(Lorg/bblfsh/client/v2/ContextExt;J)V";
+
 // Field signatures
 const char FIELD_ITER_NODE[] = "Ljava/lang/Object;";
-const char FIELD_ITER_CTX[] = "Lorg/bblfsh/client/v2/Context;";
-const char FIELD_ITER_EXT_NODE[] = "Ljava/lang/Object;";
-const char FIELD_ITER_EXT_CTX[] = "Lorg/bblfsh/client/v2/ContextExt;";
-const char FIELD_NODE_EXT_CTX[] = "Lorg/bblfsh/client/v2/ContextExt;";
+const char FIELD_CTX[] = "Lorg/bblfsh/client/v2/Context;";
+const char FIELD_CTX_EXT[] = "Lorg/bblfsh/client/v2/ContextExt;";
 
 // TODO(#114): cache classes&methods in JNI_OnLoad should speed this up
 void checkJvmException(std::string msg) {

--- a/src/main/native/jni_utils.cc
+++ b/src/main/native/jni_utils.cc
@@ -26,7 +26,8 @@ JNIEnv *getJNIEnv() {
 
 // Class fully qualified names
 const char CLS_NODE[] = "org/bblfsh/client/v2/NodeExt";
-const char CLS_CTX[] = "org/bblfsh/client/v2/ContextExt";
+const char CLS_CTX_EXT[] = "org/bblfsh/client/v2/ContextExt";
+const char CLS_CTX[] = "org/bblfsh/client/v2/Context";
 const char CLS_TO[] = "org/bblfsh/client/v2/TreeOrder";
 const char CLS_OBJ[] = "java/lang/Object";
 const char CLS_RE[] = "java/lang/RuntimeException";
@@ -57,11 +58,15 @@ const char METHOD_RE_INIT[] = "(Ljava/lang/String;)V";
 const char METHOD_RE_INIT_CAUSE[] =
     "(Ljava/lang/String;Ljava/lang/Throwable;)V";
 
-const char METHOD_ITER_INIT[] = "(Lorg/bblfsh/client/v2/NodeExt;IJJ)V";
-const char METHOD_JITER_INIT[] = "(Lorg/bblfsh/client/v2/JNode;IJJ)V";
+const char METHOD_ITER_INIT[] = "(Lorg/bblfsh/client/v2/NodeExt;IJLorg/bblfsh/client/v2/ContextExt;)V";
+const char METHOD_JITER_INIT[] = "(Lorg/bblfsh/client/v2/JNode;IJLorg/bblfsh/client/v2/Context;)V";
 
 // Field signatures
 const char FIELD_ITER_NODE[] = "Ljava/lang/Object;";
+const char FIELD_ITER_CTX[] = "Lorg/bblfsh/client/v2/Context;";
+const char FIELD_ITER_EXT_NODE[] = "Ljava/lang/Object;";
+const char FIELD_ITER_EXT_CTX[] = "Lorg/bblfsh/client/v2/ContextExt;";
+const char FIELD_NODE_EXT_CTX[] = "Lorg/bblfsh/client/v2/ContextExt;";
 
 // TODO(#114): cache classes&methods in JNI_OnLoad should speed this up
 void checkJvmException(std::string msg) {

--- a/src/main/native/jni_utils.h
+++ b/src/main/native/jni_utils.h
@@ -36,14 +36,12 @@ extern const char METHOD_RE_INIT[];
 extern const char METHOD_RE_INIT_CAUSE[];
 extern const char METHOD_ITER_INIT[];
 extern const char METHOD_JITER_INIT[];
+extern const char METHOD_NODE_INIT[];
 
 // Field signatures
 extern const char FIELD_ITER_NODE[];
-extern const char FIELD_ITER_EXT_NODE[];
-extern const char FIELD_NODE_EXT_CTX[];
-extern const char FIELD_ITER_CTX[];
-extern const char FIELD_ITER_EXT_CTX[];
-
+extern const char FIELD_CTX[];
+extern const char FIELD_CTX_EXT[];
 // Checks through JNI, if there is a pending excption on the JVM side.
 //
 // Throws new RuntimeException to the JVM in case there is,

--- a/src/main/native/jni_utils.h
+++ b/src/main/native/jni_utils.h
@@ -6,6 +6,8 @@
 
 // Fully qualified Java class names
 extern const char CLS_NODE[];
+extern const char CLS_CTX_EXT[];
+extern const char CLS_CTX[];
 extern const char CLS_CTX[];
 extern const char CLS_OBJ[];
 extern const char CLS_RE[];
@@ -37,6 +39,10 @@ extern const char METHOD_JITER_INIT[];
 
 // Field signatures
 extern const char FIELD_ITER_NODE[];
+extern const char FIELD_ITER_EXT_NODE[];
+extern const char FIELD_NODE_EXT_CTX[];
+extern const char FIELD_ITER_CTX[];
+extern const char FIELD_ITER_EXT_CTX[];
 
 // Checks through JNI, if there is a pending excption on the JVM side.
 //

--- a/src/main/native/org_bblfsh_client_v2_libuast_Libuast.cc
+++ b/src/main/native/org_bblfsh_client_v2_libuast_Libuast.cc
@@ -144,7 +144,7 @@ class ContextExt {
     delete (ctx);
 
     if (jCtxExt)
-      getJNIEnv()->DeleteGlobalRef(jCtxExt);
+      getJNIEnv()->DeleteWeakGlobalRef(jCtxExt);
   }
 
   // lookup searches for a specific node handle.
@@ -159,7 +159,7 @@ class ContextExt {
   // We need this because a NodeExt from Scala side includes
   // a Scala ContextExt and a handle to the native C node
   void setJavaContext(jobject ctx) {
-    jCtxExt = getJNIEnv()->NewGlobalRef(ctx);
+    jCtxExt = getJNIEnv()->NewWeakGlobalRef(ctx);
   }
     
   // Iterate returns iterator over an external UAST tree.

--- a/src/main/native/org_bblfsh_client_v2_libuast_Libuast.cc
+++ b/src/main/native/org_bblfsh_client_v2_libuast_Libuast.cc
@@ -1,5 +1,5 @@
 #include <cassert>
-#include <map>
+#include <unordered_map>
 
 #include "jni_utils.h"
 #include "org_bblfsh_client_v2_Context.h"
@@ -364,6 +364,7 @@ class Node : public uast::Node<Node *> {
     JNIEnv *env = getJNIEnv();
     jobject val =
         ObjectMethod(env, "valueAt", METHOD_JNODE_VALUE_AT, CLS_JNODE, obj, i);
+    // TODO(#113) investigate, it looks like a potential memory leak
     return lookupOrCreate(env->NewGlobalRef(val));  // new ref
   }
 
@@ -400,11 +401,29 @@ class Node : public uast::Node<Node *> {
   }
 };
 
+// Custom comparator for keys in std::map<object>.
+// Compares actual objects instead of JNI references.
+struct EqualByObj {
+  bool operator()(jobject a, jobject b) const {
+    return getJNIEnv()->IsSameObject(a, b);
+  }
+};
+
+// Custom hasing function for keys in std::map<object>.
+// Deligates actual hasing to the managed .hashCode() impl.
+struct HashByObj {
+  std::size_t operator()(jobject obj) const noexcept {
+    auto hash = IntMethod(getJNIEnv(), "hashCode", "()I", CLS_OBJ, obj);
+    checkJvmException("failed to call hashCode()");
+    return hash;
+  }
+};
+
 class Context;
 
 class Interface : public uast::NodeCreator<Node *> {
  private:
-  std::map<jobject, Node *> obj2node;
+  std::unordered_map<jobject, Node *, HashByObj, EqualByObj> obj2node;
 
   // lookupOrCreate either creates a new object or returns existing one.
   // In the second case it creates a new reference.
@@ -415,7 +434,7 @@ class Interface : public uast::NodeCreator<Node *> {
     if (node) return node;
 
     node = new Node(this, obj);
-    obj2node[obj] = node;
+    obj2node[node->obj] = node;
     return node;
   }
 
@@ -423,7 +442,7 @@ class Interface : public uast::NodeCreator<Node *> {
   // Steals the reference.
   Node *create(NodeKind kind, jobject obj) {
     Node *node = new Node(this, kind, obj);
-    obj2node[obj] = node;
+    obj2node[node->obj] = node;
     return node;
   }
 
@@ -441,9 +460,9 @@ class Interface : public uast::NodeCreator<Node *> {
   }
 
   // toJ returns a JVM object associated with a node.
-  // Returns a new reference.
   jobject toJ(Node *node) {
     if (!node) return nullptr;
+    // TODO(#113) investigate, it looks like a potential memory leak
     jobject obj = getJNIEnv()->NewGlobalRef(node->obj);
     return obj;
   }

--- a/src/main/native/org_bblfsh_client_v2_libuast_Libuast.cc
+++ b/src/main/native/org_bblfsh_client_v2_libuast_Libuast.cc
@@ -629,7 +629,7 @@ JNIEXPORT jobject JNICALL Java_org_bblfsh_client_v2_libuast_Libuast_decode(
   jobject jCtxExt = NewJavaObject(env, CLS_CTX, "(J)V", p);
   if (env->ExceptionCheck() || !jCtxExt) {
     jCtxExt = nullptr;
-    delete (ctx);
+    // This also deletes the underlying ctx
     delete (p);
     checkJvmException("failed to instantiate ContextExt class");
   }
@@ -838,7 +838,7 @@ JNIEXPORT jobject JNICALL Java_org_bblfsh_client_v2_ContextExt_encode(
 JNIEXPORT void JNICALL
 Java_org_bblfsh_client_v2_ContextExt_dispose(JNIEnv *env, jobject self) {
   ContextExt *p = getHandle<ContextExt>(env, self, nativeContext);
-  if (!p) {
+  if (p) {
     delete p;
     setHandle<ContextExt>(env, self, 0, nativeContext);
   }

--- a/src/main/native/project/build.properties
+++ b/src/main/native/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.2.8

--- a/src/main/native/project/build.properties
+++ b/src/main/native/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.2.8

--- a/src/main/scala/org/bblfsh/client/v2/BblfshClient.scala
+++ b/src/main/scala/org/bblfsh/client/v2/BblfshClient.scala
@@ -149,7 +149,16 @@ object BblfshClient {
     def decode(): ContextExt = {
       val bufDirectCopy = ByteBuffer.allocateDirect(buf.size)
       buf.copyTo(bufDirectCopy)
-      BblfshClient.decode(bufDirectCopy)
+      val result = BblfshClient.decode(bufDirectCopy)
+      // Sometimes the direct buffer can take a lot to deallocate,
+      // causing Out of Memory, because it is not allocated in
+      // in the JVM heap and will only be deallocated them when
+      // JVM does not have more space in its heap
+      // This line alleviates the problem
+      // Problem can be tested if we remove it and do a
+      // loop decoding a file
+      System.gc()
+      result
     }
   }
 

--- a/src/main/scala/org/bblfsh/client/v2/ContextExt.scala
+++ b/src/main/scala/org/bblfsh/client/v2/ContextExt.scala
@@ -14,8 +14,7 @@ case class ContextExt(nativeContext: Long) {
     @native def root(): NodeExt
     @native def filter(query: String): UastIterExt
     @native def encode(n: NodeExt): ByteBuffer
-
-    @native def dispose()
+    @native private def dispose()
     override def finalize(): Unit = {
         this.dispose()
     }
@@ -31,7 +30,10 @@ case class Context(nativeContext: Long) {
     @native def root(): JNode
     @native def filter(query: String, node: JNode): UastIter
     @native def encode(n: JNode): ByteBuffer
-    @native def dispose()
+    @native private def dispose()
+    override def finalize(): Unit = {
+      this.dispose
+    } 
 }
 object Context {
     @native def create(): Long

--- a/src/main/scala/org/bblfsh/client/v2/ContextExt.scala
+++ b/src/main/scala/org/bblfsh/client/v2/ContextExt.scala
@@ -14,7 +14,7 @@ case class ContextExt(nativeContext: Long) {
     @native def root(): NodeExt
     @native def filter(query: String): UastIterExt
     @native def encode(n: NodeExt): ByteBuffer
-    @native private def dispose()
+    @native def dispose()
     override def finalize(): Unit = {
         this.dispose()
     }
@@ -30,10 +30,10 @@ case class Context(nativeContext: Long) {
     @native def root(): JNode
     @native def filter(query: String, node: JNode): UastIter
     @native def encode(n: JNode): ByteBuffer
-    @native private def dispose()
+    @native def dispose()
     override def finalize(): Unit = {
-      this.dispose
-    } 
+      this.dispose()
+    }
 }
 object Context {
     @native def create(): Long

--- a/src/main/scala/org/bblfsh/client/v2/NodeExt.scala
+++ b/src/main/scala/org/bblfsh/client/v2/NodeExt.scala
@@ -12,10 +12,10 @@ import scala.collection.mutable
   * UAST representation for the nodes originated from the Go side.
   * This is equivalent of pyuast.NodeExt API.
   *
-  * @param ctx pointer to the native ContextExt
+  * @param ctx a reference to the external context
   * @param handle pointer to the native Node
   */
-case class NodeExt(ctx: Long, handle: Long) {
+case class NodeExt(ctx: ContextExt, handle: Long) {
   @native def load(): JNode
   @native def filter(query: String): UastIterExt
 }

--- a/src/main/scala/org/bblfsh/client/v2/libuast/Libuast.scala
+++ b/src/main/scala/org/bblfsh/client/v2/libuast/Libuast.scala
@@ -1,6 +1,6 @@
 package org.bblfsh.client.v2.libuast
 
-import org.bblfsh.client.v2.{ContextExt, JNode, NodeExt, TreeOrder}
+import org.bblfsh.client.v2.{ContextExt, Context, JNode, NodeExt, TreeOrder}
 import org.bblfsh.client.v2.libuast.Libuast.UastIterExt
 
 import scala.collection.Iterator
@@ -25,8 +25,8 @@ object Libuast {
     * It brides the gap between the contracts of a Scala iterator (.hasNext()/.next()) and
     * a native Libuast iterator (.next() == null at the end).
     **/
-  abstract class UastAbstractIter[T >: Null](var node: T, var treeOrder: Int, var iter: Long, var ctx: Long)
-    extends Iterator[T] {
+  abstract class UastAbstractIter[T >: Null](var node: T, var treeOrder: Int, var iter: Long)
+      extends Iterator[T] {
     private var closed = false
     private var nextNode: Option[T] = None
 
@@ -75,8 +75,8 @@ object Libuast {
   }
 
   /** Iterator over children of the given external/native node */
-  class UastIterExt(node: NodeExt, treeOrder: Int, iter: Long, ctx: Long)
-    extends UastAbstractIter(node, treeOrder, iter, ctx) {
+  class UastIterExt(node: NodeExt, treeOrder: Int, iter: Long, var ctx: ContextExt)
+    extends UastAbstractIter(node, treeOrder, iter) {
     @native def nativeNext(iterPtr: Long): NodeExt
     @native def nativeInit()
     @native def nativeDispose()
@@ -84,15 +84,15 @@ object Libuast {
 
   object UastIterExt {
     def apply(node: NodeExt, treeOrder: Int): UastIterExt = {
-      val it = new UastIterExt(node, treeOrder, 0, 0)
+      val it = new UastIterExt(node, treeOrder, 0, ContextExt(0))
       it.nativeInit()
       it
     }
   }
 
   /** Iterator over children of the given managed node */
-  class UastIter(node: JNode, treeOrder: Int, iter: Long, ctx: Long)
-    extends UastAbstractIter(node, treeOrder, iter, ctx) {
+  class UastIter(node: JNode, treeOrder: Int, iter: Long, var ctx: Context)
+    extends UastAbstractIter(node, treeOrder, iter) {
     @native def nativeNext(iterPtr: Long): JNode
     @native def nativeInit()
     @native def nativeDispose()
@@ -100,7 +100,7 @@ object Libuast {
 
   object UastIter {
     def apply(node: JNode, treeOrder: Int): UastIter = {
-      val it = new UastIter(node, treeOrder, 0, 0)
+      val it = new UastIter(node, treeOrder, 0, Context(0))
       it.nativeInit()
       it
     }

--- a/src/test/scala/org/bblfsh/client/v2/libuast/IteratorNativeTest.scala
+++ b/src/test/scala/org/bblfsh/client/v2/libuast/IteratorNativeTest.scala
@@ -45,7 +45,7 @@ class IteratorNativeTest extends FlatSpec
     iter.close()
 
     iter.hasNext() should be(false)
-    iter.ctx should be(0)
+    iter.ctx should be(null)
     iter.iter should be(0)
   }
 


### PR DESCRIPTION
This is a proposition for addressing the #113.

Original impl used a reference as a key in a native map, but in JNI object references are neither constant nor unique, and thus were violating the contract on native map `hashCode()`-equivalent for a key.

This should allow to get rid of global reference in the interface lookup, but there more (clearly identified) cases where we still rely on side-effects of having a global reference and thus leak some memory.

This seems to works on macOS but fails on linux, but needs further work:
  - this cahnge fails on linux, but works on macOS 
  - when `NewGloablRef` in interface lookup is removed, it a pre-order iterator tests

This branch is intentionally pushed to upstream repo, so @ncordon please feel free to take over and help.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/scala-client/116)
<!-- Reviewable:end -->
