### PR TITLE
build: enable sbt-git plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,9 @@
 
 name := "bblfsh-client"
 organization := "org.bblfsh"
-version := "2.0.0-SNAPSHOT"
+
+git.useGitDescribe := true
+enablePlugins(GitVersioning)
 
 scalaVersion := "2.11.11"
 val libuastVersion = "3.3.1"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,4 +3,5 @@ addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.16")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
 libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.8.3"


### PR DESCRIPTION
This adds [sbt-git](https://github.com/sbt/sbt-git) to allow reading artefact version number from the git tag on CI in release profile  instead of hard-coding it in VCS.

Fixes #80. To be tested on v2.0.0 release today.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/scala-client/117)
<!-- Reviewable:end -->
