### PR TITLE
Fixes README examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ target
 *~
 .idea
 src/libuast-native
+src/main/proto
+!src/main/proto/github.com/gogo/protobuf/gogoproto/gogo.proto
+src/main/resources
 .history
 Libuast.so
 build/*

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ val resp = client.parse(filename, fileContent, Mode.SEMANTIC)
 println(resp.get)
 
 // Filtered response
-println(client.filter(resp.get, "//uast:Import"))
+println(client.filter(resp.get, "//uast:Identifier"))
 ```
 
 Command line:
@@ -105,7 +105,7 @@ java -jar build/bblfsh-client-assembly-*.jar -f <file.py>
 or if you want to use a XPath query:
 
 ```
-java -jar build/bblfsh-client-assembly-*.jar -f <file.py> -q "//uast:Import"
+java -jar build/bblfsh-client-assembly-*.jar -f <file.py> -q "//uast:Identifier"
 ```
 
 Please read the [Babelfish clients](https://doc.bblf.sh/user/language-clients.html)

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ guide to learn more about how to use and deploy a bblfsh server, install languag
 API
 ```scala
 import scala.io.Source
-import org.bblfsh.client.BblfshClient
+import org.bblfsh.client.v2.BblfshClient, BblfshClient._
 import gopkg.in.bblfsh.sdk.v2.protocol.driver.Mode
 
 val client = BblfshClient("localhost", 9432)

--- a/src/main/scala/org/bblfsh/client/v2/BblfshClient.scala
+++ b/src/main/scala/org/bblfsh/client/v2/BblfshClient.scala
@@ -161,6 +161,14 @@ object BblfshClient {
     }
   }
 
+  /** Enables API: client.filter and client.iterator for client an instance of BblfshClient */
+  implicit class BblfshClientMethods(val client: BblfshClient) {
+    def filter(node: NodeExt, query: String) = BblfshClient.filter(node, query)
+    def filter(node: JNode, query: String) = BblfshClient.filter(node, query)
+    def iterator(node: NodeExt, treeOrder: Int) = BblfshClient.iterator(node, treeOrder)
+    def iterator(node: JNode, treeOrder: Int) = BblfshClient.iterator(node, treeOrder)
+  }
+
   /** Factory method for iterator over an external/native node */
   def iterator(node: NodeExt, treeOrder: Int): Libuast.UastIterExt = {
     Libuast.UastIterExt(node, treeOrder)


### PR DESCRIPTION
Fixes the README example, which was not completely executable. 

It adds the syntax `client.filter` and `client.iterator` for `client : BblfshClient` to get closer to the `Python` API (up until now we had to call `BblfshClient.filter` and `BblfshClient.iterator` and that was another reason why the README example did not work).

It also changes the: `client.filter(resp.get, "//uast:Import")` (which was always empty iterator, at least for a Python pile) for `client.filter(resp.get, "//*uast:Import")`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/scala-client/118)
<!-- Reviewable:end -->
