### PR TITLE
Solves linking error

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -180,7 +180,7 @@ def compileUnix(sourceFiles: String) = {
 
     checkedProcess(cmd, "macOS build")
   } else {
-    val cmd:String = "g++ -shared -Wall -fPIC -O2 -std=c++11 " +
+    val cmd:String = "g++ -shared -Wl,-Bsymbolic -Wall -fPIC -O2 -std=c++11 " +
       "-I/usr/include " +
       "-I" + javaHome + "/include/ " +
       "-I" + javaHome + "/include/linux " +


### PR DESCRIPTION
Solves #119

Taken from here: https://github.com/golang/go/issues/30822

I suppose former version of `libuast` used by `scala-client` 1.10.1 did not carry Go code, and current does. To summarize, we cannot link several C libraries which need Go runtime without that flag.

Signed-off-by: ncordon <nacho.cordon.castillo@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/scala-client/120)
<!-- Reviewable:end -->
