### PR TITLE
Bumps version of sbt-sonatype plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,9 @@
+resolvers += Resolver.jcenterRepo
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.16")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
+addSbtPlugin("ch.jodersky" % "sbt-jni" % "1.2.6")
 libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.8.3"


### PR DESCRIPTION
I think new versions of the plugin execute `sbt sonatypeClose` when they are finished with a release (either with success or failure), avoiding issues as the one we run into yesterday: several staging versions and Travis complaining it cannot do the release with more than one staging version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/scala-client/122)
<!-- Reviewable:end -->
