### PR TITLE
Changes sonatype configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,8 +81,7 @@ jobs:
         - ./sbt publishLocal
         - openssl aes-256-cbc -K $encrypted_97aef7f4ae04_key -iv $encrypted_97aef7f4ae04_iv -in key.asc.enc -out key.asc -d
         - gpg --no-default-keyring --primary-keyring ./project/.gnupg/pubring.gpg --secret-keyring ./project/.gnupg/secring.gpg --keyring ./project/.gnupg/pubring.gpg --fingerprint --import key.asc
-        - ./sbt publishSigned
-        - ./sbt sonatypeRelease
+        - ./sbt sonatypeDrop publishSigned sonatypeRelease
 
     - <<: *release
       name: 'Check that project can be cross-compiled correctly'

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ resolvers += Resolver.jcenterRepo
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.16")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
 addSbtPlugin("ch.jodersky" % "sbt-jni" % "1.2.6")


### PR DESCRIPTION
* Reverts the version of sonatype (`publishSigned` is failing saying: `PUT operation to URL https://oss.sonatype.org/service/local/staging/deploy/maven2/org/bblfsh/bblfsh-client/2.0.2/bblfsh-client-2.0.2.jar failed with status code 503: Service Temporarily Unavailable`
* Also adds `sonatypeDrop` to `build.sbt` trying to erase staging repositories

Signed-off-by: ncordon <nacho.cordon.castillo@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/scala-client/125)
<!-- Reviewable:end -->
