### PR TITLE
Adds value based filtering

### DIFF
--- a/src/main/scala/org/bblfsh/client/v2/BblfshClient.scala
+++ b/src/main/scala/org/bblfsh/client/v2/BblfshClient.scala
@@ -240,9 +240,10 @@ object BblfshClient {
     // do not dispose the context, iterator steals it
   }
 
-  // Method to filter managed nodes based on type
-  // The aim is to not return a JNode but a specialized subclass of JNode, as JBool,
-  // for example, when T = JBool
+  /** Method to filter managed nodes based on type
+    * The aim is to not return a JNode but a specialized subclass of JNode, as JBool,
+    * for example, when T = JBool
+    */
   private def filterOnType[T : ClassTag](node: JNode, query: String): Iterator[T] = {
     val it = filter(node, query)
     // Filter only the nodes that are of type T

--- a/src/test/scala/org/bblfsh/client/v2/BblfshClientParseTest.scala
+++ b/src/test/scala/org/bblfsh/client/v2/BblfshClientParseTest.scala
@@ -54,7 +54,6 @@ class BblfshClientParseTest extends BblfshClientBaseTest {
     encodedBytes shouldEqual resp.uast.asReadOnlyByteBuffer
   }
 
-
   "Encoding python UAST to a new Context" should "produce the same bytes" in {
     val fileName = "src/test/resources/python_file.py"
     val fileContent = Source.fromFile(fileName).getLines.mkString("\n")


### PR DESCRIPTION
Exposes, in `BblfshClient`:

* `filterInt` -> returns only nodes for the query which are `JInt`s
* `filterUint` -> analogously, but with `JUint`s
* `filterFloat` -> same for `JFloat`s
* `filterString` -> same for `JString`s
* `filterBool` -> same for `JBool`s

Note that we may want to have a clear answer for #127 before merging this, because in the python-client (where we do not have `uint`s) the analogous functionality is to call:

```python
it = filter(resp.get, boolean(//*))

for node:
  # This may fail if any of the nodes we are filtering is not of boolean type
  node.get_bool()
```

Also in the issue we were talking about `filterNum`, but unless we have a type that groups `JFloat`, `JInt` and `JUint`, we cannot do that. Moreover, in the `python-client`, the filtering of `float`s is separated from the filtering of `int`s.

Closes #110

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/scala-client/128)
<!-- Reviewable:end -->
