### PR TITLE
Reverts the sonatypeDrop from #125

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ jobs:
         - ./sbt publishLocal
         - openssl aes-256-cbc -K $encrypted_97aef7f4ae04_key -iv $encrypted_97aef7f4ae04_iv -in key.asc.enc -out key.asc -d
         - gpg --no-default-keyring --primary-keyring ./project/.gnupg/pubring.gpg --secret-keyring ./project/.gnupg/secring.gpg --keyring ./project/.gnupg/pubring.gpg --fingerprint --import key.asc
-        - ./sbt sonatypeDrop publishSigned sonatypeRelease
+        - ./sbt publishSigned sonatypeRelease
 
     - <<: *release
       name: 'Check that project can be cross-compiled correctly'


### PR DESCRIPTION
This `sonatypeDrop` command will make the build fail if there is not a staging repository to drop

Signed-off-by: ncordon <nacho.cordon.castillo@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/scala-client/129)
<!-- Reviewable:end -->
