### PR TITLE
Adds gRPC timeout parameter and bumps default timeout

### DIFF
--- a/src/main/scala/org/bblfsh/client/v2/BblfshClient.scala
+++ b/src/main/scala/org/bblfsh/client/v2/BblfshClient.scala
@@ -5,11 +5,13 @@ import java.nio.ByteBuffer
 import com.google.protobuf.ByteString
 import gopkg.in.bblfsh.sdk.v2.protocol.driver._
 import io.grpc.ManagedChannelBuilder
+import java.util.concurrent.TimeUnit
 import org.bblfsh.client.v2.libuast.Libuast
 
 
 class BblfshClient(host: String, port: Int, maxMsgSize: Int) {
-  private val DEFAULT_TIMEOUT_SEC = 5
+  // 1 minute default timeout
+  val DEFAULT_TIMEOUT_SEC = 60
 
   private val channel = ManagedChannelBuilder
     .forAddress(host, port)
@@ -46,7 +48,7 @@ class BblfshClient(host: String, port: Int, maxMsgSize: Int) {
       language = lang,
       mode = mode
     )
-    stub.parse(req)
+    stub.withDeadlineAfter(timeout, TimeUnit.SECONDS).parse(req)
   }
 
   /**


### PR DESCRIPTION
Closes #100 

`timeout` was not working with the migration to `v2`. And based on the feedback:
- @creachadair proposed to increase default timeout to 1 or 2 min. Done!. But note we should probably do the same in the `python-client` then, which if no timeout is passed, I think it will not timeout.
- @dennwc proposed to unify the API for the `BblfshClient.parse` method, adding default parameters. Although I am in favour of that, adding default parameters will break the API for a Java user of this package: source [here](https://docs.scala-lang.org/tour/default-parameter-values.html). 

For example a method:

```
def Point(val x: Double = 0)
```

could be called as `Point()` in Scala, but not in Java.

If we unify `parse` methods we have to bump the major version of the package. So wdyt?

Signed-off-by: ncordon <nacho.cordon.castillo@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/scala-client/133)
<!-- Reviewable:end -->
