### PR TITLE
Ignores test resource files in linguist detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+src/test/resources/* linguist-vendored


### PR DESCRIPTION
Makes linguist statistics show this is a Scala repo, not a PHP one :rofl: 

Signed-off-by: ncordon <nacho.cordon.castillo@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/scala-client/137)
<!-- Reviewable:end -->
