### PR TITLE
Reduces size of native shared libraries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ This section has more extended documentation for a brave developer willing to
 contribute by diving into and coding / debugging for the native glue code in `src/main/native`.
 
 ## Generate C headers for native code
-A method must be marked as `@native` in the Scala part for us to be able to code it natively in C. 
+A method must be marked as `@native` in the Scala part for us to be able to code it natively in C.
 Example:
 
 ```scala
@@ -37,17 +37,19 @@ Sadly, on non-linux OSes you might still experience issues with CGO due to https
 
 
 ## Build libscalauast with debug symbols
-Compiler flags need to be `-g -O0` used instead of `-fPIC -O2` that is used for releases:
+Compiler flags need to be `-g -O0` used instead of `-fPIC -O2` that is used for releases. `JAVA_HOME` needs to
+be correctly configured (see [README.md](README.md) for more details).
 ```
-$ g++ -shared -Wall -g -std=c++11 -O0 \
-      -I/usr/include \
-      "-I${JAVA_HOME}/include" \
-      "-I${JAVA_HOME}/include/${platform}" \
-      -Isrc/main/resources/libuast \
-      -o "src/main/resources/lib/libscalauast${platform_ext}" \
-      src/main/native/org_bblfsh_client_v2_libuast_Libuast.cc \
-      src/main/native/jni_utils.cc src/main/resources/libuast/libuast.a
+./build.sh --compile-dev
 ```
+
+Note if something fails, it may be necessary to do:
+```
+./build.sh --clean --get-dependencies
+```
+
+since that would fetch the `.proto` files needed to talk to `bblfshd`, and repeat from step
+[Build libuast with debug symbols](#build-libuast-with-debug-symbols)
 
 ## Run a single test under debugger
 To run a single test from CLI one can:

--- a/build.sbt
+++ b/build.sbt
@@ -24,10 +24,11 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 )
 
+// Exclude resources/libuast folder in .jar generated with sbt assembly
+excludeFilter in unmanagedResources := "libuast"
+
 assemblyMergeStrategy in assembly := {
-  case "META-INF/io.netty.versions.properties" =>
-    MergeStrategy.last
-  case "META-INF\\io.netty.versions.properties" =>
+  case "META-INF/io.netty.versions.properties" | "META-INF\\io.netty.versions.properties" =>
     MergeStrategy.last
   case x =>
     val oldStrategy = (assemblyMergeStrategy in assembly).value

--- a/build.sh
+++ b/build.sh
@@ -20,7 +20,7 @@ LIBUAST_VERSION="3.4.2"
 UNZIP_DIR="sdk-${SDK_VERSION:1}"
 BBLFSH_PROTO="${PROTO_DIR}/github.com/bblfsh"
 SDK_PROTO="${BBLFSH_PROTO}/sdk/${SDK_MAJOR}"
-CPP_FLAGS="-shared -Wall -fPIC -O2 -std=c++11"
+CPP_FLAGS="-shared -s -Wall -fPIC -O2 -std=c++11"
 
 function setOSEnv {
     case $OSTYPE in
@@ -127,7 +127,7 @@ function compileNativeCode {
         ${SRC_FILES} \
         src/main/resources/libuast/libuast${LIBUAST_FMT}
     find ${OUT_FOLDER}
-
+    
     echo "[native-code] Done compiling libuast bindings..." 1>&2
 }
 


### PR DESCRIPTION
Uses `g++ -s` to strip all debug symbols and ignores `libuast.a` and `libuast.so` in the resulting `.jar` file. Note the contents of `libuast` folder were no needed in the `.jar` since we have already created `libscalauast.so` using the static library.

This should reduce the size of the `.jar`s even now that we have three flavours of `libscalauast` dynamic library (for Linux, macOS and Windows)

Closes #85 

Signed-off-by: ncordon <nacho.cordon.castillo@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/scala-client/139)
<!-- Reviewable:end -->
