### PR TITLE
Cleans JNI warnings

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -153,7 +153,7 @@ function usage() {
 }
 
 if [ "$#" -eq 0 ]; then
-    usage && exit -4
+    usage
 fi
 
 for arg in "$@"; do

--- a/build.sh
+++ b/build.sh
@@ -162,7 +162,7 @@ for arg in "$@"; do
             cleanFiles
             ;;
         "--get-dependencies")
-            getSDKFiles
+            getSDKFiles && \
             getLibuast
             ;;
         "--native")
@@ -185,4 +185,9 @@ for arg in "$@"; do
             usage
             ;;
     esac
+
+    # Avoids executing further commands if previous one failed
+    if [ $? -ne 0 ]; then
+        break;
+    fi
 done

--- a/src/main/native/jni_utils.cc
+++ b/src/main/native/jni_utils.cc
@@ -144,6 +144,7 @@ void checkJvmException(std::string msg) {
 
 jobject NewJavaObject(JNIEnv *env, const char *className, const char *initSign,
                       ...) {
+  // global ref
   jclass cls = FindClass(env, className);
   checkJvmException(std::string("failed to find a class ").append(className));
 
@@ -179,6 +180,7 @@ jfieldID FieldID(JNIEnv *env, jobject obj, const char *field,
                         .append(typeSignature)
                         .append("'"));
 
+  env->DeleteLocalRef(cls);
   return fId;
 }
 

--- a/src/main/native/jni_utils.h
+++ b/src/main/native/jni_utils.h
@@ -74,6 +74,7 @@ void checkJvmException(std::string);
 JNIEnv *getJNIEnv();
 
 // Constructs new Java object of a given className and constructor signature.
+// Returns a local reference.
 jobject NewJavaObject(JNIEnv *, const char *, const char *, ...);
 
 // Returns the field ID of the field of the given object.
@@ -86,6 +87,7 @@ jint IntField(JNIEnv *, jobject, const char *, const char *);
 
 // Reads the value of an Object field of a given object.
 // The field is specified by its name and signature.
+// Returns a local reference.
 jobject ObjectField(JNIEnv *, jobject, const char *, const char *);
 
 // Returns the method ID for a method of a given class or interface name.
@@ -99,6 +101,7 @@ jint IntMethod(JNIEnv *, const char *, const char *, const char *,
 
 // Calls a method of the given class or interface name that returns an Object.
 // The method is determined by its name and signature.
+// Returns a local reference.
 jobject ObjectMethod(JNIEnv *, const char *, const char *, const char *,
                      const jobject, ...);
 

--- a/src/main/native/org_bblfsh_client_v2_libuast_Libuast.cc
+++ b/src/main/native/org_bblfsh_client_v2_libuast_Libuast.cc
@@ -386,9 +386,11 @@ class Node : public uast::Node<Node *> {
   void SetValue(size_t i, Node *val) {
     JNIEnv *env = getJNIEnv();
     jobject v = nullptr;
-    bool isLocal = !(val && val->obj);
+    bool createLocal = !(val && val->obj);
 
-    if (isLocal) {
+    // If val->obj does not exist, create a local reference
+    // otherwise v would contain a global reference to val->obj
+    if (createLocal) {
       v = NewJavaObject(env, CLS_JNULL, "()V");
     } else {
       v = val->obj;
@@ -400,15 +402,17 @@ class Node : public uast::Node<Node *> {
                           .append(".add() from Node::SetValue()"));
 
     env->DeleteLocalRef(res);
-    if (isLocal)
+    if (createLocal)
       env->DeleteLocalRef(v);
   }
   void SetKeyValue(std::string key, Node *val) {
     JNIEnv *env = getJNIEnv();
     jobject v = nullptr;
-    bool isLocal = !(val && val->obj);
+    bool createLocal = !(val && val->obj);
 
-    if (isLocal) {
+    // If val->obj does not exist, create a local reference
+    // otherwise v would contain a global reference to val->obj
+    if (createLocal) {
       v = NewJavaObject(env, CLS_JNULL, "()V");
     } else {
       v = val->obj;
@@ -423,7 +427,7 @@ class Node : public uast::Node<Node *> {
 
     env->DeleteLocalRef(k);
     env->DeleteLocalRef(res);
-    if (isLocal)
+    if (createLocal)
       env->DeleteLocalRef(v);
   }
 };
@@ -723,7 +727,7 @@ Java_org_bblfsh_client_v2_libuast_Libuast_00024UastIter_nativeInit(
   setHandle<uast::Iterator<Node *>>(env, self, it, "iter");
   // this.ctx = Context(ctx);
   setObjectField(env, self, jCtx, "ctx", FIELD_CTX);
-  
+
   return;
 }
 


### PR DESCRIPTION
Important warnings erased are the ones about the accumulation of local references in the `load` and `filter` methods, i.e. imagine we had a giant tree and we call `load()` over an external node. Then since methods from `Interface` in the JNI code (`Interface` is in charge of creating the nodes) were creating a lot of local references and not releasing them we could end up with an Out of Memory in the JNI side due to the accumulation of references. To exemplify this, running `testOnly org.bblfsh.client.v2.FilterNativeMethod` showed warnings about creating ~2500 local references for a quite small tree.


Left warnings when we do:

```bash
export JVM_OPTS='-Xcheck:jni'
./sbt test
```
are:

* `sbt` side warnings (before the tests actually execute). The proof for that is that if we do just `./sbt` they also arise.
* `Warning: SIGSEGV handler expected:libjvm.so+0x86be80  found:libscalauast_312939638902511669.so+0x1c7ef0` and similar: this ones disappear after we execute `test` again. I think they have more to do with `sbt`.
* 
```
WARNING: JNI local refs: 33, exceeds capacity: 32
	at java.net.NetworkInterface.getAll(Native Method)
	at java.net.NetworkInterface.getNetworkInterfaces(NetworkInterface.java:355)
	at io.netty.util.NetUtil.<clinit>(NetUtil.java:168)
	at io.netty.util.internal.MacAddressUtil.bestAvailableMac(MacAddressUtil.java:50)
	at io.netty.util.internal.MacAddressUtil.defaultMachineId(MacAddressUtil.java:138)
	at io.netty.channel.DefaultChannelId.<clinit>(DefaultChannelId.java:99)
	at io.netty.channel.AbstractChannel.newId(AbstractChannel.java:111)
	at io.netty.channel.AbstractChannel.<init>(AbstractChannel.java:83)
	at io.netty.channel.nio.AbstractNioChannel.<init>(AbstractNioChannel.java:84)
	at io.netty.channel.nio.AbstractNioByteChannel.<init>(AbstractNioByteChannel.java:66)
	at io.netty.channel.socket.nio.NioSocketChannel.<init>(NioSocketChannel.java:104)
``` 
This one is coming from `nio` library, we cannot do anything about them

*  
```
WARNING in native method: JNI call made without checking exceptions when required to from CallStaticVoidMethod
	at java.lang.Object.getClass(Native Method)
```
This one is coming from `.getClass()` method in Java. We cannot do anything about it either.

* 
```
WARNING in native method: JNI call made without checking exceptions when required to from CallStaticVoidMethod
	at java.lang.Runtime.runFinalization0(Native Method)
```
Similarly






Closes #112

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/scala-client/140)
<!-- Reviewable:end -->
